### PR TITLE
probe-rs-cli-ftdi: init at 0.12.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,10 @@ rec {
     inherit pylink-square012;
     inherit cmsis-pack-manager;
   };
+
+  probe-rs-cli-ftdi = pkgs.callPackage ./pkgs/probe-rs-cli-ftdi { };
+
+  #
   # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
   # ...
 }

--- a/pkgs/probe-rs-cli-ftdi/default.nix
+++ b/pkgs/probe-rs-cli-ftdi/default.nix
@@ -1,0 +1,6 @@
+{ probe-rs-cli, libftdi1 }:
+
+probe-rs-cli.overrideAttrs (finalAtrrs: prevAttrs: {
+  buildInputs = prevAttrs.buildInputs ++ [ libftdi1 ];
+  cargoBuildFeatures = ["ftdi"];
+})


### PR DESCRIPTION
The package `probe-rs-cli-ftdi` modifies the existing `probe-rs-cli`
package by enabling the `ftdi` feature.